### PR TITLE
Add backend-specific database managers with PostgreSQL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,30 @@ MEMORY_DB_PATH="/Your/Path/To/memory.db" memento
 ## @iachilles/memento v0.3.3 is ready!
 ```
 
+## Configuration
+
+Memento now supports pluggable storage backends. Configuration is controlled
+entirely through environment variables so it remains easy to embed inside MCP
+workflows.
+
+| Variable | Description |
+| --- | --- |
+| `MEMORY_DB_DRIVER` | Optional selector for the database backend. Defaults to `sqlite`. Set to `postgres` to enable the PostgreSQL manager. |
+| `MEMORY_DB_PATH` | Filesystem path for the SQLite database file (only used when the driver is `sqlite`). |
+| `SQLITE_VEC_PATH` | Optional absolute path to a pre-built `sqlite-vec` extension shared library. |
+| `MEMORY_DB_DSN` / `DATABASE_URL` | PostgreSQL connection string consumed by the `pg` client. |
+| `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE` | Individual PostgreSQL connection parameters. Used when no DSN is provided. |
+| `PGSSLMODE` | When set to `require`, SSL will be enabled with `rejectUnauthorized: false`. |
+
+### PostgreSQL notes
+
+- The PostgreSQL manager requires the [`pgvector`](https://github.com/pgvector/pgvector)
+  extension. It is automatically initialized with `CREATE EXTENSION IF NOT EXISTS vector`.
+- Schema management currently mirrors the SQLite layout so both backends expose
+  the same tables. Advanced SQLite features (FTS5, sqlite-vec) are still required
+  by the current knowledge-graph implementation, so PostgreSQL support should be
+  considered experimental until the higher-level query layer is updated.
+
 Claude Desktop:
 
 ```

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { createRequire } from 'module';
-import { DbManager } from './src/db-manager.js';
+import { createDbManager } from './src/db-manager.js';
 import { KnowledgeGraphManager } from './src/knowledge-graph-manager.js';
 import { Server } from './src/server.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -20,10 +20,22 @@ if (engines?.node) {
     }
 }
 
-const dbManager = new DbManager(
-    process.env.MEMORY_DB_PATH,
-    process.env.SQLITE_VEC_PATH
-);
+const dbManager = createDbManager({
+    driver: process.env.MEMORY_DB_DRIVER,
+    sqlite: {
+        dbPath: process.env.MEMORY_DB_PATH,
+        sqliteVecPath: process.env.SQLITE_VEC_PATH
+    },
+    postgres: {
+        connectionString: process.env.MEMORY_DB_DSN || process.env.DATABASE_URL,
+        host: process.env.PGHOST,
+        port: process.env.PGPORT,
+        user: process.env.PGUSER,
+        password: process.env.PGPASSWORD,
+        database: process.env.PGDATABASE,
+        ssl: process.env.PGSSLMODE === 'require' ? { rejectUnauthorized: false } : undefined
+    }
+});
 const db = await dbManager.db();
 const knowledgeGraphManager = new KnowledgeGraphManager(db);
 const transport = new StdioServerTransport();

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@xenova/transformers": "^2.17.2",
+    "pg": "^8.12.0",
     "sqlite": "^5.1.1",
     "sqlite-vec": "^0.1.7-alpha.2",
     "sqlite3": "^5.1.7",

--- a/src/db-manager.js
+++ b/src/db-manager.js
@@ -1,9 +1,7 @@
 /**
  * @file db-manager.js
  * @description
- * Provides database initialization and management for SQLite with FTS5 and sqlite-vec support.
- * Handles opening the database, enabling foreign keys, loading the sqlite-vec extension,
- * and creating necessary tables for entities, observations, and relations.
+ * Provides database initialization and management for different storage backends.
  */
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -12,14 +10,18 @@ import sqlite3 from 'sqlite3';
 import { getLoadablePath, load as loadSqliteVec } from 'sqlite-vec';
 import { MigrationManager } from './migration-manager.js';
 import { migrations } from '../migrations/index.js';
+import pg from 'pg';
+
+const { Pool } = pg;
 
 const DEFAULT_DB_FILENAME = 'memory.db';
+const DEFAULT_DRIVER = 'sqlite';
 
 /**
  * Manages SQLite database connections and schema for the knowledge graph.
  * @class
  */
-export class DbManager {
+export class SqliteDbManager {
     /**
      * Absolute path to the SQLite database file.
      * @private
@@ -42,7 +44,7 @@ export class DbManager {
     #db = null;
 
     /**
-     * Creates a new DbManager.
+     * Creates a new SqliteDbManager.
      * @param {string|null} [dbPath=null]
      *   Path to the SQLite database file. If null, uses the default location.
      * @param {string|null} [sqliteVecPath=null]
@@ -138,7 +140,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS obs_vec USING vec0(entity_id INT, embedding F
 -- Trigger for insert
 CREATE TRIGGER IF NOT EXISTS obs_fts_insert AFTER INSERT ON observations
 BEGIN
-    INSERT INTO obs_fts(rowid, content, entity_id) 
+    INSERT INTO obs_fts(rowid, content, entity_id)
     VALUES (new.id, new.content, new.entity_id);
 END;
 
@@ -151,7 +153,7 @@ END;
 -- Trigger for update
 CREATE TRIGGER IF NOT EXISTS obs_fts_update AFTER UPDATE ON observations
 BEGIN
-    UPDATE obs_fts 
+    UPDATE obs_fts
     SET content = new.content, entity_id = new.entity_id
     WHERE rowid = new.id;
 END;
@@ -181,4 +183,211 @@ END;
                ? dbPath
                : path.join(path.dirname(fileURLToPath(import.meta.url)), dbPath);
     }
+}
+
+/**
+ * Manages PostgreSQL database connections and schema.
+ */
+export class PostgresDbManager {
+    /** @type {pg.Pool|null} */
+    #pool = null;
+
+    /** @type {pg.PoolConfig} */
+    #config;
+
+    constructor(config = {}) {
+        this.#config = this.#sanitizeConfig(config);
+    }
+
+    /**
+     * Returns an initialized PostgreSQL pool.
+     * @returns {Promise<pg.Pool>}
+     */
+    async db() {
+        if (!this.#pool) {
+            this.#pool = new Pool(this.#config);
+            await this.#initialize();
+        }
+
+        return this.#pool;
+    }
+
+    async #initialize() {
+        const client = await this.#pool.connect();
+        try {
+            await client.query('BEGIN');
+            await this.#ensureVectorExtension(client);
+            await this.#createTables(client);
+            await this.#createTriggers(client);
+            await client.query('COMMIT');
+        } catch (error) {
+            await client.query('ROLLBACK');
+            throw error;
+        } finally {
+            client.release();
+        }
+    }
+
+    async #ensureVectorExtension(client) {
+        await client.query('CREATE EXTENSION IF NOT EXISTS vector');
+    }
+
+    async #createTables(client) {
+        await client.query(`
+            CREATE TABLE IF NOT EXISTS entities (
+                id SERIAL PRIMARY KEY,
+                name TEXT UNIQUE NOT NULL,
+                entitytype TEXT NOT NULL
+            )
+        `);
+
+        await client.query(`
+            CREATE TABLE IF NOT EXISTS observations (
+                id SERIAL PRIMARY KEY,
+                entity_id INTEGER NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+                content TEXT NOT NULL,
+                UNIQUE(entity_id, content)
+            )
+        `);
+
+        await client.query(`
+            CREATE TABLE IF NOT EXISTS relations (
+                id SERIAL PRIMARY KEY,
+                from_id INTEGER NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+                to_id INTEGER NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+                relationtype TEXT NOT NULL,
+                UNIQUE(from_id, to_id, relationtype)
+            )
+        `);
+
+        await client.query(`
+            CREATE TABLE IF NOT EXISTS obs_vec (
+                observation_id INTEGER PRIMARY KEY,
+                entity_id INTEGER NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+                embedding vector(1024)
+            )
+        `);
+
+        await client.query(`
+            CREATE TABLE IF NOT EXISTS obs_fts (
+                rowid INTEGER PRIMARY KEY,
+                content TEXT NOT NULL,
+                entity_id INTEGER NOT NULL REFERENCES entities(id) ON DELETE CASCADE
+            )
+        `);
+    }
+
+    async #createTriggers(client) {
+        await client.query(`
+            CREATE OR REPLACE FUNCTION obs_fts_sync_insert() RETURNS trigger AS $$
+            BEGIN
+                INSERT INTO obs_fts(rowid, content, entity_id)
+                VALUES (NEW.id, NEW.content, NEW.entity_id)
+                ON CONFLICT (rowid) DO UPDATE
+                SET content = EXCLUDED.content,
+                    entity_id = EXCLUDED.entity_id;
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+        `);
+
+        await client.query(`
+            CREATE OR REPLACE FUNCTION obs_fts_sync_delete() RETURNS trigger AS $$
+            BEGIN
+                DELETE FROM obs_fts WHERE rowid = OLD.id;
+                RETURN OLD;
+            END;
+            $$ LANGUAGE plpgsql;
+        `);
+
+        await client.query(`
+            CREATE OR REPLACE FUNCTION obs_fts_sync_update() RETURNS trigger AS $$
+            BEGIN
+                UPDATE obs_fts
+                SET content = NEW.content,
+                    entity_id = NEW.entity_id
+                WHERE rowid = NEW.id;
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+        `);
+
+        await client.query('DROP TRIGGER IF EXISTS obs_fts_insert ON observations');
+        await client.query(`
+            CREATE TRIGGER obs_fts_insert
+            AFTER INSERT ON observations
+            FOR EACH ROW EXECUTE FUNCTION obs_fts_sync_insert()
+        `);
+
+        await client.query('DROP TRIGGER IF EXISTS obs_fts_delete ON observations');
+        await client.query(`
+            CREATE TRIGGER obs_fts_delete
+            AFTER DELETE ON observations
+            FOR EACH ROW EXECUTE FUNCTION obs_fts_sync_delete()
+        `);
+
+        await client.query('DROP TRIGGER IF EXISTS obs_fts_update ON observations');
+        await client.query(`
+            CREATE TRIGGER obs_fts_update
+            AFTER UPDATE ON observations
+            FOR EACH ROW EXECUTE FUNCTION obs_fts_sync_update()
+        `);
+    }
+
+    #sanitizeConfig(config) {
+        const sanitized = {};
+
+        if (config.connectionString) {
+            sanitized.connectionString = config.connectionString;
+        }
+
+        for (const [key, value] of Object.entries(config)) {
+            if (key === 'connectionString') continue;
+            if (value === undefined || value === null || value === '') continue;
+            sanitized[key] = key === 'port' ? Number(value) : value;
+        }
+
+        return sanitized;
+    }
+}
+
+/**
+ * Factory helper for creating a database manager based on configuration.
+ * @param {{
+ *   driver?: string,
+ *   sqlite?: { dbPath?: string|null, sqliteVecPath?: string|null },
+ *   postgres?: {
+ *     connectionString?: string,
+ *     host?: string,
+ *     port?: string|number,
+ *     user?: string,
+ *     password?: string,
+ *     database?: string,
+ *     ssl?: import('pg').PoolConfig['ssl']
+ *   }
+ * }} [options]
+ * @returns {SqliteDbManager|PostgresDbManager}
+ */
+export function createDbManager(options = {}) {
+    const driver = (options.driver || process.env.MEMORY_DB_DRIVER || DEFAULT_DRIVER).toLowerCase();
+
+    if (driver === 'postgres' || driver === 'postgresql' || driver === 'pg') {
+        const envConnectionString = process.env.MEMORY_DB_DSN || process.env.DATABASE_URL;
+        const postgresOptions = {
+            connectionString: options.postgres?.connectionString ?? envConnectionString,
+            host: options.postgres?.host ?? process.env.PGHOST,
+            port: options.postgres?.port ?? process.env.PGPORT,
+            user: options.postgres?.user ?? process.env.PGUSER,
+            password: options.postgres?.password ?? process.env.PGPASSWORD,
+            database: options.postgres?.database ?? process.env.PGDATABASE,
+            ssl: options.postgres?.ssl ?? (process.env.PGSSLMODE === 'require' ? { rejectUnauthorized: false } : undefined)
+        };
+
+        return new PostgresDbManager(postgresOptions);
+    }
+
+    return new SqliteDbManager(
+        options.sqlite?.dbPath ?? process.env.MEMORY_DB_PATH ?? null,
+        options.sqlite?.sqliteVecPath ?? process.env.SQLITE_VEC_PATH ?? null
+    );
 }

--- a/src/knowledge-graph-manager.js
+++ b/src/knowledge-graph-manager.js
@@ -231,7 +231,7 @@ export class KnowledgeGraphManager {
         return {
             entities:  ents.map(e => ({
                 name:         e.name,
-                entityType:   e.entityType,
+                entityType:   e.entityType ?? e.entitytype,
                 observations: obs
                                   .filter(o => o.entity_id === e.id)
                                   .map(o => o.content)
@@ -239,7 +239,7 @@ export class KnowledgeGraphManager {
             relations: relRows.map(r => ({
                 from:         r.fn,
                 to:           r.tn,
-                relationType: r.relationType
+                relationType: r.relationType ?? r.relationtype
             }))
         };
     }
@@ -399,7 +399,7 @@ export class KnowledgeGraphManager {
         return {
             entities:  ents.map(e => ({
                 name:         e.name,
-                entityType:   e.entityType,
+                entityType:   e.entityType ?? e.entitytype,
                 observations: obs
                                   .filter(o => o.entity_id === e.id)
                                   .map(o => o.content)
@@ -407,7 +407,7 @@ export class KnowledgeGraphManager {
             relations: rel.map(r => ({
                 from:         r.fn,
                 to:           r.tn,
-                relationType: r.relationType
+                relationType: r.relationType ?? r.relationtype
             }))
         };
     }
@@ -532,7 +532,7 @@ export class KnowledgeGraphManager {
 
         const placeholders = entityIds.map(() => "?").join(",");
         const results = await this.#db.all(
-            `SELECT 
+            `SELECT
                 e.id as entity_id,
                 e.name,
                 e.entityType,
@@ -554,7 +554,10 @@ export class KnowledgeGraphManager {
             entityIds
         );
 
-        return results;
+        return results.map(row => ({
+            ...row,
+            entityType: row.entityType ?? row.entitytype
+        }));
     }
 
     /**


### PR DESCRIPTION
## Summary
- split the legacy DbManager into backend-specific SqliteDbManager and PostgresDbManager classes behind a new createDbManager factory
- initialize the PostgreSQL backend with the pg client, pgvector extension, and schema/triggers that mirror the SQLite structure while keeping the SQLite setup isolated
- document the new configuration environment variables and add the pg dependency while normalizing entity/relation casing lookups for cross-backend compatibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2b0bffb0083239d84ee138d24a6d0