### PR TITLE
Add optional JSONL write hook events

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Each line is a JSON object with an ISO `timestamp`, an `operation`, and the chan
 {"timestamp":"2026-05-05T16:33:16.619Z","operation":"create_entity","entity":{"name":"Hook Test","entityType":"test"}}
 ```
 
-Supported operations are `create_entity`, `add_observations`, `create_relation`, `delete_entities`, `delete_relations`, `delete_observations`, and `set_importance`.
+Supported operations are `create_entity`, `add_observations`, `create_relation`, `delete_entities`, `delete_relations`, `delete_observations`, and `set_importance`. Delete events are emitted only for records that were actually removed.
 
 Hook write failures are logged to stderr but do not fail the graph mutation that already succeeded. Consumers that require strict reconciliation should combine the hook with occasional `read_graph` or targeted `open_nodes` checks.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,25 @@ workflows.
 | `MEMORY_DB_DSN` / `DATABASE_URL` | PostgreSQL connection string consumed by the `pg` client. |
 | `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE` | Individual PostgreSQL connection parameters. Used when no DSN is provided. |
 | `PGSSLMODE` | When set to `require`, SSL will be enabled with `rejectUnauthorized: false`. |
+| `MEMENTO_WRITE_HOOK_PATH` | Optional path to a JSON Lines file. When set, Memento appends one event after each successful graph mutation. |
+
+### Write hook events
+
+Set `MEMENTO_WRITE_HOOK_PATH` when another process needs to react to memory writes without polling the full graph:
+
+```bash
+MEMENTO_WRITE_HOOK_PATH=/tmp/memento-events.jsonl memento
+```
+
+Each line is a JSON object with an ISO `timestamp`, an `operation`, and the changed entity/relation payload. Example:
+
+```json
+{"timestamp":"2026-05-05T16:33:16.619Z","operation":"create_entity","entity":{"name":"Hook Test","entityType":"test"}}
+```
+
+Supported operations are `create_entity`, `add_observations`, `create_relation`, `delete_entities`, `delete_relations`, `delete_observations`, and `set_importance`.
+
+Hook write failures are logged to stderr but do not fail the graph mutation that already succeeded. Consumers that require strict reconciliation should combine the hook with occasional `read_graph` or targeted `open_nodes` checks.
 
 ### PostgreSQL notes
 
@@ -108,6 +127,8 @@ This server exposes the following MCP tools:
 - `search_nodes`
 - `open_nodes`
 - `set_importance` - Set importance level (critical/important/normal/temporary/deprecated)
+
+When `MEMENTO_WRITE_HOOK_PATH` is configured, mutating tools also append JSONL write events for downstream consumers.
 #### An example of an instruction set that an LLM should know for effective memory handling (see MEMORY_PROTOCOL.md)
 
 ## Embedding Model

--- a/src/graph-repository.js
+++ b/src/graph-repository.js
@@ -25,9 +25,9 @@
  * @property {(entityId: number|string, content: string) => Promise<ObservationInsertResult>} insertObservation
  * @property {(rows: Array<{ observationId: number|string, entityId: number|string, embedding: Buffer }>) => Promise<void>} insertObservationVectors
  * @property {(fromId: number|string, toId: number|string, relationType: string) => Promise<boolean>} createRelation
- * @property {(names: string[]) => Promise<void>} deleteEntities
- * @property {(relations: Array<{ from: string, to: string, relationType: string }>) => Promise<void>} deleteRelations
- * @property {(entityId: number|string, observations: string[]) => Promise<void>} deleteObservations
+ * @property {(names: string[]) => Promise<string[]>} deleteEntities
+ * @property {(relations: Array<{ from: string, to: string, relationType: string }>) => Promise<Array<{ from: string, to: string, relationType: string }>>} deleteRelations
+ * @property {(entityId: number|string, observations: string[]) => Promise<string[]>} deleteObservations
  * @property {() => Promise<{ entities: Array<{ name: string, entityType: string, observations: string[] }>, relations: Array<{ from: string, to: string, relationType: string }> }>} readGraph
  * @property {(vector: number[], topK: number) => Promise<Array<{ entity_id: number|string, distance: number }>>} semanticSearch
  * @property {(entityIds: Array<number|string>) => Promise<Array<{ entity_id: number|string, name: string, entityType: string, created_at: string|null, last_accessed: string|null, access_count: number|null, importance: string|null }>>} fetchEntitiesWithDetails

--- a/src/knowledge-graph-manager.js
+++ b/src/knowledge-graph-manager.js
@@ -131,9 +131,9 @@ export class KnowledgeGraphManager {
      * @returns {Promise<void>}
      */
     async deleteEntities(names) {
-        await this.#repository.deleteEntities(names);
-        if (names.length) {
-            await this.#notifyWrite({ operation: 'delete_entities', entityNames: names });
+        const deletedNames = await this.#repository.deleteEntities(names);
+        if (deletedNames.length) {
+            await this.#notifyWrite({ operation: 'delete_entities', entityNames: deletedNames });
         }
     }
 
@@ -145,9 +145,9 @@ export class KnowledgeGraphManager {
      * @returns {Promise<void>}
      */
     async deleteRelations(relations) {
-        await this.#repository.deleteRelations(relations);
-        if (relations.length) {
-            await this.#notifyWrite({ operation: 'delete_relations', relations });
+        const deletedRelations = await this.#repository.deleteRelations(relations);
+        if (deletedRelations.length) {
+            await this.#notifyWrite({ operation: 'delete_relations', relations: deletedRelations });
         }
     }
 
@@ -162,9 +162,9 @@ export class KnowledgeGraphManager {
         for (const { entityName, observations } of list) {
             const entityId = await this.#repository.getEntityId(entityName);
             if (!entityId) continue;
-            await this.#repository.deleteObservations(entityId, observations);
-            if (observations.length) {
-                await this.#notifyWrite({ operation: 'delete_observations', entityName, observations });
+            const deletedObservations = await this.#repository.deleteObservations(entityId, observations);
+            if (deletedObservations.length) {
+                await this.#notifyWrite({ operation: 'delete_observations', entityName, observations: deletedObservations });
             }
         }
     }

--- a/src/knowledge-graph-manager.js
+++ b/src/knowledge-graph-manager.js
@@ -7,6 +7,7 @@
 
 import { pipeline } from '@xenova/transformers';
 import { SearchContextManager } from './search-context-manager.js';
+import { WriteHook } from './write-hook.js';
 
 export class KnowledgeGraphManager {
     /**
@@ -20,14 +21,20 @@ export class KnowledgeGraphManager {
     /** @type {SearchContextManager} */
     #searchContextManager;
 
+    /** @type {WriteHook} */
+    #writeHook;
+
     /**
      * Creates a new KnowledgeGraphManager.
      * @param {import('./graph-repository.js').GraphRepository} repository
      *   Graph repository implementation for data persistence.
+     * @param {{ writeHook?: WriteHook, writeHookOptions?: { path?: string|null } }} [options]
+     *   Optional write hook configuration.
      */
-    constructor(repository) {
+    constructor(repository, options = {}) {
         this.#repository = repository;
         this.#searchContextManager = new SearchContextManager(repository);
+        this.#writeHook = options.writeHook || new WriteHook(options.writeHookOptions);
     }
 
     /**
@@ -45,6 +52,10 @@ export class KnowledgeGraphManager {
             if (!existingId) {
                 await this.#repository.createEntity(entity.name, entity.entityType);
                 created.push(entity);
+                await this.#notifyWrite({
+                    operation: 'create_entity',
+                    entity: { name: entity.name, entityType: entity.entityType }
+                });
             }
             if (entity.observations?.length) {
                 await this.addObservations([{ entityName: entity.name, contents: entity.observations }]);
@@ -80,6 +91,11 @@ export class KnowledgeGraphManager {
                     embedding: embeddings[index]
                 }));
                 await this.#repository.insertObservationVectors(vectorRows);
+                await this.#notifyWrite({
+                    operation: 'add_observations',
+                    entityName,
+                    observations: inserted.map(item => item.content)
+                });
             }
             results.push({ entityName, addedObservations: inserted.map(item => item.content) });
         }
@@ -102,6 +118,7 @@ export class KnowledgeGraphManager {
             const inserted = await this.#repository.createRelation(fromId, toId, relation.relationType);
             if (inserted) {
                 created.push(relation);
+                await this.#notifyWrite({ operation: 'create_relation', relation });
             }
         }
         return created;
@@ -115,6 +132,9 @@ export class KnowledgeGraphManager {
      */
     async deleteEntities(names) {
         await this.#repository.deleteEntities(names);
+        if (names.length) {
+            await this.#notifyWrite({ operation: 'delete_entities', entityNames: names });
+        }
     }
 
     /**
@@ -126,6 +146,9 @@ export class KnowledgeGraphManager {
      */
     async deleteRelations(relations) {
         await this.#repository.deleteRelations(relations);
+        if (relations.length) {
+            await this.#notifyWrite({ operation: 'delete_relations', relations });
+        }
     }
 
     /**
@@ -140,6 +163,9 @@ export class KnowledgeGraphManager {
             const entityId = await this.#repository.getEntityId(entityName);
             if (!entityId) continue;
             await this.#repository.deleteObservations(entityId, observations);
+            if (observations.length) {
+                await this.#notifyWrite({ operation: 'delete_observations', entityName, observations });
+            }
         }
     }
 
@@ -333,6 +359,10 @@ export class KnowledgeGraphManager {
 
             const success = await this.#searchContextManager.setImportance(entityId, importance);
 
+            if (success) {
+                await this.#notifyWrite({ operation: 'set_importance', entityName, importance });
+            }
+
             return {
                 success,
                 entityName,
@@ -345,5 +375,15 @@ export class KnowledgeGraphManager {
         } catch (error) {
             return { success: false, error: error.message };
         }
+    }
+
+    /**
+     * Emits a mutation event for configured write hooks.
+     * @private
+     * @param {object} event
+     * @returns {Promise<void>}
+     */
+    async #notifyWrite(event) {
+        await this.#writeHook.notify(event);
     }
 }

--- a/src/postgres/graph-repo.js
+++ b/src/postgres/graph-repo.js
@@ -234,19 +234,22 @@ export class PostgresGraphRepository {
      * Deletes entities by their names.
      * @async
      * @param {string[]} names - Array of entity names to delete.
-     * @returns {Promise<void>}
+     * @returns {Promise<string[]>} Names of entities that were deleted.
      */
     async deleteEntities(names) {
         if (!names.length) {
-            return;
+            return [];
         }
 
-        await this.#query(
+        const rows = await this.#query(
             `DELETE
              FROM entities
-             WHERE name = ANY ($1)`,
+             WHERE name = ANY ($1)
+             RETURNING name`,
             [ names ]
         );
+
+        return rows.map(row => row.name);
     }
 
     /**
@@ -254,9 +257,11 @@ export class PostgresGraphRepository {
      * @async
      * @param {Array<{from: string, to: string, relationType: string}>} relations
      *   Array of relations to delete with entity names and relation type.
-     * @returns {Promise<void>}
+     * @returns {Promise<Array<{from: string, to: string, relationType: string}>>}
+     *   Array of relations that were deleted.
      */
     async deleteRelations(relations) {
+        const deleted = [];
         for (const relation of relations) {
             const fromId = await this.getEntityId(relation.from);
             const toId = await this.getEntityId(relation.to);
@@ -264,15 +269,21 @@ export class PostgresGraphRepository {
                 continue;
             }
 
-            await this.#query(
+            const rows = await this.#query(
                 `DELETE
                  FROM relations
                  WHERE from_id = $1
                    AND to_id = $2
-                   AND relationtype = $3`,
+                   AND relationtype = $3
+                 RETURNING id`,
                 [ fromId, toId, relation.relationType ]
             );
+            if (rows.length) {
+                deleted.push(relation);
+            }
         }
+
+        return deleted;
     }
 
     /**
@@ -280,20 +291,23 @@ export class PostgresGraphRepository {
      * @async
      * @param {number} entityId - Entity ID from which to delete observations.
      * @param {string[]} observations - Array of observation content strings to delete.
-     * @returns {Promise<void>}
+     * @returns {Promise<string[]>} Observation texts that were deleted.
      */
     async deleteObservations(entityId, observations) {
         if (!observations.length) {
-            return;
+            return [];
         }
 
-        await this.#query(
+        const rows = await this.#query(
             `DELETE
              FROM observations
              WHERE entity_id = $1
-               AND content = ANY ($2)`,
+               AND content = ANY ($2)
+             RETURNING content`,
             [ entityId, observations ]
         );
+
+        return rows.map(row => row.content);
     }
 
     /**

--- a/src/sqlite/graph-repo.js
+++ b/src/sqlite/graph-repo.js
@@ -137,15 +137,20 @@ export class SqliteGraphRepository {
      * Deletes entities by their names.
      * @async
      * @param {string[]} names - Array of entity names to delete.
-     * @returns {Promise<void>}
+     * @returns {Promise<string[]>} Names of entities that were deleted.
      */
     async deleteEntities(names) {
         if (!names.length) {
-            return;
+            return [];
         }
 
         const placeholders = names.map(() => '?').join(',');
-        await this.db.run(`DELETE FROM entities WHERE name IN (${placeholders})`, names);
+        const deletedRows = await this.db.all(
+            `DELETE FROM entities WHERE name IN (${placeholders}) RETURNING name`,
+            names
+        );
+
+        return deletedRows.map(row => row.name);
     }
 
     /**
@@ -153,18 +158,25 @@ export class SqliteGraphRepository {
      * @async
      * @param {Array<{from: string, to: string, relationType: string}>} relations
      *   Array of relations to delete with entity names and relation type.
-     * @returns {Promise<void>}
+     * @returns {Promise<Array<{from: string, to: string, relationType: string}>>}
+     *   Array of relations that were deleted.
      */
     async deleteRelations(relations) {
+        const deleted = [];
         for (const relation of relations) {
             const fromId = await this.getEntityId(relation.from);
             const toId = await this.getEntityId(relation.to);
             if (!fromId || !toId) continue;
-            await this.db.run(
-                `DELETE FROM relations WHERE from_id = ? AND to_id = ? AND relationType = ?`,
+            const deletedRows = await this.db.all(
+                `DELETE FROM relations WHERE from_id = ? AND to_id = ? AND relationType = ? RETURNING id`,
                 [fromId, toId, relation.relationType]
             );
+            if (deletedRows.length) {
+                deleted.push(relation);
+            }
         }
+
+        return deleted;
     }
 
     /**
@@ -172,18 +184,20 @@ export class SqliteGraphRepository {
      * @async
      * @param {number} entityId - Entity ID from which to delete observations.
      * @param {string[]} observations - Array of observation content strings to delete.
-     * @returns {Promise<void>}
+     * @returns {Promise<string[]>} Observation texts that were deleted.
      */
     async deleteObservations(entityId, observations) {
         if (!observations.length) {
-            return;
+            return [];
         }
 
         const placeholders = observations.map(() => '?').join(',');
-        await this.db.run(
-            `DELETE FROM observations WHERE entity_id = ? AND content IN (${placeholders})`,
+        const deletedRows = await this.db.all(
+            `DELETE FROM observations WHERE entity_id = ? AND content IN (${placeholders}) RETURNING content`,
             [entityId, ...observations]
         );
+
+        return deletedRows.map(row => row.content);
     }
 
     /**

--- a/src/write-hook.js
+++ b/src/write-hook.js
@@ -1,0 +1,53 @@
+/**
+ * @file write-hook.js
+ * @description
+ * Optional durable write event sink for consumers that need to react to
+ * knowledge graph mutations without polling the full graph.
+ */
+import { appendFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * Appends knowledge graph mutation events to a JSON Lines file.
+ */
+export class WriteHook {
+    /**
+     * @param {{ path?: string|null }} [options]
+     */
+    constructor(options = {}) {
+        this.path = options.path || process.env.MEMENTO_WRITE_HOOK_PATH || null;
+    }
+
+    /**
+     * @returns {boolean} True when event output is configured.
+     */
+    get enabled() {
+        return Boolean(this.path);
+    }
+
+    /**
+     * Emits an event after a successful mutation.
+     *
+     * Hook failures are logged but do not fail the already-committed graph write.
+     * Consumers that require reconciliation should combine this with periodic reads.
+     *
+     * @param {object} event
+     * @returns {Promise<void>}
+     */
+    async notify(event) {
+        if (!this.path) {
+            return;
+        }
+
+        try {
+            await mkdir(path.dirname(this.path), { recursive: true });
+            await appendFile(
+                this.path,
+                `${JSON.stringify({ timestamp: new Date().toISOString(), ...event })}\n`,
+                'utf8'
+            );
+        } catch (error) {
+            console.error('Memento write hook failed:', error?.message ?? error);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add optional `MEMENTO_WRITE_HOOK_PATH` configuration for JSONL mutation events
- Emit events after successful graph mutations: entity/observation/relation writes, deletes, and importance updates
- Document the write hook format and reconciliation caveat in the README

## Why
Downstream consumers sometimes need to react to memory changes without polling the entire graph. A durable JSONL event sink provides a simple, opt-in integration point while keeping the existing MCP API unchanged.

## Verification
- `node --check src/write-hook.js`
- `node --check src/knowledge-graph-manager.js`
- SQLite smoke test covering create entity, add observations, create relation, set importance, deletes, and JSONL event output
- `git diff --check`
